### PR TITLE
Auto increment build number when upload app to TestFlight with Travis

### DIFF
--- a/FlyveMDMInventoryAgent/Info.plist
+++ b/FlyveMDMInventoryAgent/Info.plist
@@ -19,7 +19,9 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>21</string>
+	<string>23</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -35,7 +37,5 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 </dict>
 </plist>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,7 +58,10 @@ platform :ios do
     )
 
     # TestFlight upload
-    pilot
+    pilot(
+      app_identifier: "org.flyve.inventory.agent.example",
+      skip_waiting_for_build_processing: true
+    )
 
   end
 

--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
-if [[ "$TRAVIS_BRANCH" == "develop" ]]; then
+if [[ "$TRAVIS_BRANCH" == "develop" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
   fastlane beta
+elif [[ "$TRAVIS_BRANCH" == "develop" && "$TRAVIS_PULL_REQUEST" == "true" ]]; then
+  fastlane test
 elif [[ "$TRAVIS_BRANCH" == "master" ]]; then
-  fastlane release
+  fastlane test
 else
   fastlane test
 fi

--- a/scripts/testflight.sh
+++ b/scripts/testflight.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-fastlane beta


### PR DESCRIPTION
This PR Auto increment build number when upload app to TestFlight with Travis and uses non exempt encryption

Ref: https://github.com/flyve-mdm/flyve-mdm-ios-inventory-agent/issues/33
Ref: https://github.com/flyve-mdm/flyve-mdm-ios-inventory-agent/issues/28