### PR TITLE
Add gh-pages branch to blacklist of Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,10 @@ machine:
     CERTIFICATES_PATH: ./ci/cert
   xcode:
     version: 9.0
+general:
+  branches:
+    ignore:
+      - gh-pages
 checkout:
   post:
     - git tag | xargs git tag -d


### PR DESCRIPTION
Hi, @ajsb85 / @rafaelje 

This PR adds gh-pages branch to blacklist of Circle CI

ref: https://github.com/flyve-mdm/flyve-mdm-press-kit/issues/36